### PR TITLE
log to stderr instead of custom file

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -1,6 +1,7 @@
 # coding: UTF-8
 
 === unreleased
+  * log to stderr instead of custom file
 
 === 0.0.7
   * now officially supported by Crate Data and available under the

--- a/lib/crate_ruby.rb
+++ b/lib/crate_ruby.rb
@@ -30,7 +30,7 @@ module CrateRuby
   def self.logger
     @logger ||= begin
       require 'logger'
-      log = Logger.new(File.join(File.dirname(__FILE__), "../log/crate.log"), 10, 1024000)
+      log = Logger.new(STDERR)
       log.level = Logger::INFO
       log
     end


### PR DESCRIPTION
TBH, i have no idea what the original intention of a custom logfile inside a gem was.
Looks like leftover debug code to me. The proper fix would be to eliminate the logger.
This change merely mitigates some specific problems with using the gem as an external dependency,
where it resides in a global dir rather than in the application.
- If it does not have the necessary permissions to write to its own library dir it'll just crash.
- Might cause unexpected out of disk issues when the rbenv is on a pre-built system partition.
- Causes race conditions when loading the gem in two apps or maybe even just two threads.
