### PR TITLE
Pass HTTP options when performing a query

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - "1.9.3"
   - "2.0.0"
   - "2.1.5"
   - "2.2.0"
@@ -8,9 +7,8 @@ sudo:
   false
 
 before_script:
-  - wget https://cdn.crate.io/downloads/releases/crate-0.47.3.tar.gz -O /tmp/crate.tar.gz
+  - wget https://cdn.crate.io/downloads/releases/crate-0.48.2.tar.gz -O /tmp/crate.tar.gz
   - tar -xvf /tmp/crate.tar.gz
-  - bundle exec ruby spec/test_server.rb $PWD/crate-0.47.3/ true
+  - bundle exec ruby spec/test_server.rb $PWD/crate-0.48.2/ true
 
 script: bundle exec rspec spec
-

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Official Ruby library to access a [Crate](http://crate.io) database.
 
 ## Installation
 
+This gem requires Ruby 2.0 or greater.
+
 Add this line to your application's Gemfile:
 
     gem 'crate_ruby'
@@ -81,4 +83,3 @@ Please refer to CONTRIBUTING.rst for further information.
 
 ##License & Copyright
 See LICENSE for details.
-

--- a/crate_ruby.gemspec
+++ b/crate_ruby.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.description   = "A Ruby interface for Crate, the distributed database for Docker."
   spec.homepage      = "http://crate.io"
   spec.license       = "Apache License, v2.0"
+  spec.required_ruby_version = '>= 2.0'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/history.txt
+++ b/history.txt
@@ -1,5 +1,7 @@
 # coding: UTF-8
 
+  * removed ruby 1.9.3 from travis.yml
+  * client now supports HTTP options
   * update travis.yml and fix broken test
 
 === 0.0.7

--- a/spec/crate_ruby/client_spec.rb
+++ b/spec/crate_ruby/client_spec.rb
@@ -123,6 +123,13 @@ describe CrateRuby::Client do
         client.refresh_table table_name
         client.execute(%Q{select * from #{table_name}})
       end
+
+      it 'should accept http options' do
+        client.execute("CREATE TABLE  #{table_name} (id STRING PRIMARY KEY, name string, address object) ")
+        client.execute(%Q{INSERT INTO  #{table_name} (address, id, name) VALUES ({street='1010 W 2nd Ave',city='Vancouver'}, 'fb7183ac-d049-462c-85a9-732aca59a1c1', 'Mad Max')})
+        client.refresh_table table_name
+        expect { client.execute("SELECT * FROM #{table_name}", nil, {read_timeout: 0}) }.to raise_error Net::ReadTimeout
+      end
     end
 
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,3 +20,4 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 require_relative '../lib/crate_ruby'
+require 'net/http'


### PR DESCRIPTION
You can now pass HTTP options when executing a query ; for example:

```
client.execute('select * from t', nil, { read_timeout: 42 })
```