### PR TITLE
Prevent Base64 wrapping in basic auth headers

### DIFF
--- a/lib/crate_ruby/client.rb
+++ b/lib/crate_ruby/client.rb
@@ -243,7 +243,7 @@ module CrateRuby
     end
 
     def encrypted_credentials
-      @encrypted_credentials ||= Base64.encode64 "#{username}:#{password}"
+      @encrypted_credentials ||= Base64.strict_encode64 "#{username}:#{password}"
     end
   end
 end


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

When the username/password for a CrateDB cluster is particularly long, the default behavior of `Base64.encode64` is to wrap with a line feed at 60 characters. This results in an invalid basic authentication header. Thankfully, the `Base64` module also implements a `.strict_encode64` method that does _not_ add any line feeds to the generated content, and is thus suitable for this purpose.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
