### PR TITLE
CI: Update software versions on CI/GHA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ] # , windows-latest ]
-        ruby-version: [ "2.6", "2.7", "3.0" ]
+        ruby-version: [ "2.6", "2.7", "3.0", "3.1" ]
 
     name: Ruby ${{ matrix.ruby-version }} on OS ${{ matrix.os }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
       - name: Acquire sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -25,14 +25,14 @@ jobs:
           architecture: x64
 
       - name: Caching of CrateDB
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-cratedb
         with:
           path: parts
           key: cratedb-os=${{ matrix.os }}-${{ hashFiles('spec/bootstrap.rb') }}
 
       - name: Caching of Ruby gems
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-gems
         with:
           path: vendor/bundle

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -54,6 +54,6 @@ Build the new gem::
 
 Publish the new gem::
 
-    $ gem push crate_ruby-<VERISON>.gem
+    $ gem push crate_ruby-<VERSION>.gem
 
-Here, ``<VERISON>`` is the version you are releasing.
+Here, ``<VERSION>`` is the version you are releasing.

--- a/spec/bootstrap.rb
+++ b/spec/bootstrap.rb
@@ -29,7 +29,7 @@ require 'rubygems/package'
 require 'zlib'
 
 class Bootstrap
-  VERSION = '4.5.0'
+  VERSION = '5.1.1'
 
   def initialize
     @fname = "crate-#{VERSION}.tar.gz"


### PR DESCRIPTION
What the title says. Add Ruby 3.1. Use CrateDB 5.1.1.