### PR TITLE
CI: Re-enable testing on Ruby 2.4 and 2.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ] # , windows-latest ]
-        ruby-version: [ "2.6", "2.7", "3.0", "3.1" ]
+        ruby-version: [ "2.4", "2.5", "2.6", "2.7", "3.0", "3.1" ]
 
     name: Ruby ${{ matrix.ruby-version }} on OS ${{ matrix.os }}
     steps:

--- a/crate_ruby.gemspec
+++ b/crate_ruby.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'A Ruby interface for CrateDB featuring query support, DDL command shortcuts, and support for BLOB tables'
   spec.homepage      = 'https://crate.io'
   spec.license       = 'Apache-2.0'
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.files         = Dir['lib/**/*']
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
It is currently needed to support `activerecord-crate-adapter`.
