### PR TITLE
CI: Add Ruby 3.2 to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Bundle install
         run: |
-          gem install bundler
+          gem install bundler --version '< 2.4'
           bundle config path vendor/bundle
           bundle install
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ] # , windows-latest ]
-        ruby-version: [ "2.4", "2.5", "2.6", "2.7", "3.0", "3.1" ]
+        ruby-version: [ "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2" ]
 
     name: Ruby ${{ matrix.ruby-version }} on OS ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Ruby 3.2.0 has been released on 25 Dec 2022.