### PR TITLE
Chore: Fix CI to use previous runners, for supporting older Ruby

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ] # , windows-latest ]
+        os: [ "ubuntu-22.04", "macos-13" ] # , windows-latest ]
         ruby-version: [ "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2" ]
 
     name: Ruby ${{ matrix.ruby-version }} on OS ${{ matrix.os }}


### PR DESCRIPTION
Just maintenance. What the title says.