### PR TITLE
CI: Ruby 3.4 and 4.0 fail on macOS 15 Intel, let's skip those

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,11 @@ jobs:
           "4.0",
           "head",
         ]
+        exclude:
+          - os: 'macos-15-intel'
+            ruby-version: '3.4'
+          - os: 'macos-15-intel'
+            ruby-version: '4.0'
 
     name: Ruby ${{ matrix.ruby-version }} on OS ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Just CI maintenance.