### PR TITLE
CI: Stop testing Ruby 2.0 on Ubuntu 22

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,9 @@ jobs:
           "4.0",
           "head",
         ]
+        exclude:
+          - os: "ubuntu-22.04"
+            ruby-version: "2.0"
 
     name: Ruby ${{ matrix.ruby-version }} on OS ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Just CI maintenance.

```ruby
Gem::InstallError: gzip error installing
/home/runner/work/crate_ruby/crate_ruby/vendor/bundle/cache/rspec-core-3.13.6.gem An error occurred while installing rspec-core (3.13.6), and Bundler cannot continue.
Make sure that `gem install rspec-core -v '3.13.6' --source 'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  rspec was resolved to 3.13.2, which depends on
    rspec-core
Error: Process completed with exit code 5.
```
